### PR TITLE
Add music video creation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+.Python
+env/
+build/
+dist/
+
+# Video and frame outputs
+data/
+_temp_frames/
+output.mp4
+model.pth

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# creating_MV
+# Creating Music Videos
+
+This repository contains a simple pipeline for creating music videos using
+scraped video data and a small generative model. The workflow consists of four
+steps:
+
+1. **Scrape training data** – download sample videos from a web page.
+2. **Preprocess the data** – extract image frames from those videos.
+3. **Train a model** – train a lightweight autoencoder on the frames.
+4. **Generate output** – produce new frames with the model and combine them
+   with an audio track to create a music video.
+
+## Setup
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. **Download videos**
+
+   ```bash
+   python scrape_data.py "https://example.com/videos" --out data/raw --limit 5
+   ```
+
+   Replace the URL with a page that contains video files you are permitted to
+   download.
+   Ensure that scraping this site is allowed by its terms of service.
+
+2. **Extract frames**
+
+   ```bash
+   python preprocess_data.py data/raw --out data/frames --fps 1
+   ```
+
+3. **Train the autoencoder**
+
+   ```bash
+   python train_model.py data/frames --epochs 10 --device cpu --out model.pth
+   ```
+
+4. **Generate a music video**
+
+   ```bash
+   python generate_output.py model.pth path/to/music.mp3 --out output.mp4
+   ```
+
+The final video will be saved as `output.mp4`.

--- a/generate_output.py
+++ b/generate_output.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+import torch
+from torchvision import transforms
+from moviepy.editor import ImageSequenceClip, AudioFileClip
+from PIL import Image
+
+from train_model import Autoencoder
+
+
+def load_model(model_path: str, device: str = "cpu") -> Autoencoder:
+    model = Autoencoder()
+    state_dict = torch.load(model_path, map_location=device)
+    model.load_state_dict(state_dict)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def generate_frames(model: Autoencoder, num_frames: int, device: str = "cpu"):
+    frames = []
+    noise = torch.randn(num_frames, 3, 128, 128, device=device)
+    with torch.no_grad():
+        outputs = model(noise).cpu()
+    to_pil = transforms.ToPILImage()
+    for i in range(num_frames):
+        img = to_pil(outputs[i])
+        frames.append(img)
+    return frames
+
+
+def create_video(frames, audio_path: str, output_file: str, fps: int = 24):
+    frame_paths = []
+    temp_dir = Path("_temp_frames")
+    temp_dir.mkdir(exist_ok=True)
+    for i, frame in enumerate(frames):
+        frame_path = temp_dir / f"frame_{i:04d}.png"
+        frame.save(frame_path)
+        frame_paths.append(str(frame_path))
+
+    clip = ImageSequenceClip(frame_paths, fps=fps)
+    if audio_path:
+        audio = AudioFileClip(audio_path)
+        clip = clip.set_audio(audio)
+    clip.write_videofile(output_file)
+
+    for p in frame_paths:
+        os.remove(p)
+    temp_dir.rmdir()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a music video using a trained model")
+    parser.add_argument("model", help="Path to trained model file")
+    parser.add_argument("audio", help="Path to audio file")
+    parser.add_argument("--frames", type=int, default=120, help="Number of frames to generate")
+    parser.add_argument("--fps", type=int, default=24, help="Frame rate for the video")
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--out", default="output.mp4", help="Output video file")
+    args = parser.parse_args()
+
+    model = load_model(args.model, args.device)
+    frames = generate_frames(model, args.frames, args.device)
+    create_video(frames, args.audio, args.out, args.fps)
+    print(f"Video saved to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+from moviepy.editor import VideoFileClip
+
+
+def extract_frames(video_path: str, output_dir: str, fps: int = 1):
+    """Extract frames from a video.
+
+    Parameters
+    ----------
+    video_path : str
+        Path to a video file.
+    output_dir : str
+        Directory where frames will be saved.
+    fps : int, optional
+        Frames per second to extract, by default 1.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    clip = VideoFileClip(video_path)
+    duration = int(clip.duration)
+    for t in range(0, duration * fps):
+        frame_time = t / fps
+        frame = clip.get_frame(frame_time)
+        frame_img = os.path.join(output_dir, f"{Path(video_path).stem}_{t:04d}.jpg")
+        from PIL import Image
+
+        Image.fromarray(frame).save(frame_img)
+    clip.close()
+
+
+def process_directory(input_dir: str, output_dir: str, fps: int = 1):
+    for fname in os.listdir(input_dir):
+        if fname.lower().endswith((".mp4", ".mov", ".webm")):
+            extract_frames(os.path.join(input_dir, fname), output_dir, fps)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract frames from videos")
+    parser.add_argument("input_dir", help="Directory with downloaded videos")
+    parser.add_argument("--out", default="data/frames", help="Where to save frames")
+    parser.add_argument("--fps", type=int, default=1, help="Frames per second to extract")
+    args = parser.parse_args()
+
+    process_directory(args.input_dir, args.out, args.fps)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+beautifulsoup4
+torch
+torchvision
+moviepy
+scikit-learn

--- a/scrape_data.py
+++ b/scrape_data.py
@@ -1,0 +1,57 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+
+def download_videos(base_url: str, output_dir: str, limit: int = 10):
+    """Download video files from a web page.
+
+    Parameters
+    ----------
+    base_url : str
+        Page containing <video> or <a> tags linking to video files.
+    output_dir : str
+        Directory where downloaded videos will be stored.
+    limit : int, optional
+        Maximum number of videos to download, by default 10.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    resp = requests.get(base_url)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    count = 0
+    for tag in soup.find_all(["video", "a"]):
+        src = tag.get("src") or tag.get("href")
+        if not src:
+            continue
+        if not src.lower().endswith((".mp4", ".mov", ".webm")):
+            continue
+        video_url = urljoin(base_url, src)
+        fname = os.path.join(output_dir, os.path.basename(src))
+        with requests.get(video_url, stream=True) as r:
+            r.raise_for_status()
+            with open(fname, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        count += 1
+        if count >= limit:
+            break
+    print(f"Downloaded {count} videos to {output_dir}")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Download sample videos for training")
+    parser.add_argument("url", help="URL of the page to scrape")
+    parser.add_argument("--out", default="data/raw", help="Output directory")
+    parser.add_argument("--limit", type=int, default=10, help="Number of videos to download")
+    args = parser.parse_args()
+
+    download_videos(args.url, args.out, args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+
+def build_dataloader(data_dir: str, batch_size: int = 32) -> DataLoader:
+    transform = transforms.Compose([
+        transforms.Resize((128, 128)),
+        transforms.ToTensor(),
+    ])
+    dataset = datasets.ImageFolder(data_dir, transform=transform)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+
+class Autoencoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv2d(3, 16, 3, stride=2, padding=1),
+            nn.ReLU(True),
+            nn.Conv2d(16, 32, 3, stride=2, padding=1),
+            nn.ReLU(True),
+            nn.Conv2d(32, 64, 7),
+        )
+        self.decoder = nn.Sequential(
+            nn.ConvTranspose2d(64, 32, 7),
+            nn.ReLU(True),
+            nn.ConvTranspose2d(32, 16, 3, stride=2, padding=1, output_padding=1),
+            nn.ReLU(True),
+            nn.ConvTranspose2d(16, 3, 3, stride=2, padding=1, output_padding=1),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        x = self.encoder(x)
+        x = self.decoder(x)
+        return x
+
+
+def train(model: nn.Module, dataloader: DataLoader, epochs: int = 5, lr: float = 1e-3, device: str = "cpu"):
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    model.to(device)
+    for epoch in range(epochs):
+        total_loss = 0.0
+        for imgs, _ in dataloader:
+            imgs = imgs.to(device)
+            optimizer.zero_grad()
+            outputs = model(imgs)
+            loss = criterion(outputs, imgs)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * imgs.size(0)
+        avg_loss = total_loss / len(dataloader.dataset)
+        print(f"Epoch {epoch+1}/{epochs}, Loss: {avg_loss:.4f}")
+
+    return model
+
+
+def save_model(model: nn.Module, path: str):
+    torch.save(model.state_dict(), path)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train an autoencoder on video frames")
+    parser.add_argument("data_dir", help="Directory with extracted frames organized by class")
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--out", default="model.pth", help="Output model file")
+    args = parser.parse_args()
+
+    dataloader = build_dataloader(args.data_dir, args.batch_size)
+    model = Autoencoder()
+    trained_model = train(model, dataloader, args.epochs, args.lr, args.device)
+    save_model(trained_model, args.out)
+    print(f"Model saved to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a scraping script for downloading videos
- preprocess videos to extract frames
- train a small autoencoder on frames
- generate output video with audio track
- document workflow in README
- add requirements and gitignore

## Testing
- `python3 -m py_compile scrape_data.py preprocess_data.py train_model.py generate_output.py`

------
https://chatgpt.com/codex/tasks/task_e_6847fbff2d3c832cb75f4c860a876aba