### PR TITLE
Improve docs and scraper flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir uv \
+    && uv pip install -r requirements.txt
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
+# Creating Music Videos
+
+This repository contains a minimal pipeline for creating music videos using a simple autoencoder. The workflow is split into four scripts that handle scraping videos, extracting frames, training a model and finally generating a video.
+
+## Prerequisites
+
+* Python 3.8 or higher
+* [`ffmpeg`](https://ffmpeg.org) must be available on your system for `moviepy` to work.
+
+## Setting up a `uv` environment
+
+[`uv`](https://github.com/astral-sh/uv) can be used to create an isolated Python environment and install the dependencies very quickly.
+
+```bash
+# install uv if you don't have it
+pip install uv
+
+# create and activate a virtual environment
+uv venv .venv
+source .venv/bin/activate
+
+# install required packages
+uv pip install -r requirements.txt
+```
+
+## Step-by-step usage
+
+1. **Scrape videos**
+
+   Download videos from a web page or from a list of pages:
+
+   ```bash
+   # single URL
+   python scrape_data.py https://example.com/videos --out data/raw --limit 10
+
+   # multiple URLs listed in urls.txt
+   python scrape_data.py --urls-file urls.txt --out data/raw --limit 10
+   ```
+
+2. **Preprocess videos**
+
+   Extract frames from the downloaded videos:
+
+   ```bash
+   python preprocess_data.py data/raw --out data/frames --fps 1 --subdir training
+   ```
+
+3. **Train the model**
+
+   ```bash
+   python train_model.py data/frames --epochs 5 --batch-size 32 --out models/autoencoder.pth
+   ```
+
+4. **Generate a music video**
+
+   ```bash
+   python generate_output.py models/autoencoder.pth path/to/song.mp3 --frames 120 --fps 24 --out output.mp4
+   ```
+
+## Docker usage
+
+A simple `Dockerfile` is provided. Build the image and run the commands inside the container:
+
+```bash
+docker build -t music-video .
+
+docker run --rm -v $(pwd):/app music-video \
+    python scrape_data.py --help
+```
+
+Replace the command after the image name with any of the steps described above.
 

--- a/scrape_data.py
+++ b/scrape_data.py
@@ -45,12 +45,25 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Download sample videos for training")
-    parser.add_argument("url", help="URL of the page to scrape")
+    parser.add_argument("url", nargs="?", help="URL of the page to scrape")
+    parser.add_argument("--urls-file", help="File containing one URL per line")
     parser.add_argument("--out", default="data/raw", help="Output directory")
-    parser.add_argument("--limit", type=int, default=10, help="Number of videos to download")
+    parser.add_argument("--limit", type=int, default=10, help="Number of videos to download from each page")
     args = parser.parse_args()
 
-    download_videos(args.url, args.out, args.limit)
+    if not args.url and not args.urls_file:
+        parser.error("provide a URL or --urls-file")
+
+    urls = []
+    if args.urls_file:
+        with open(args.urls_file) as f:
+            urls.extend([line.strip() for line in f if line.strip()])
+    if args.url:
+        urls.append(args.url)
+
+    for idx, u in enumerate(urls, start=1):
+        out_dir = os.path.join(args.out, f"url_{idx}") if len(urls) > 1 else args.out
+        download_videos(u, out_dir, args.limit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document how to run the video creation pipeline
- mention prerequisites and how to install packages with **uv** or Docker
- add `--urls-file` option for scraping many pages
- include minimal Dockerfile

## Testing
- `python -m py_compile scrape_data.py preprocess_data.py train_model.py generate_output.py`

------
https://chatgpt.com/codex/tasks/task_e_68486e423ac0832c9a34ff8e523623a9