### PR TITLE
Add multi-url batch scraping utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ Regular `pip` also works if you prefer.
 
 1. **Download videos**
 
-   ```bash
+```bash
    scripts/scrape_data https://example.com/videos --out data/raw --limit 10
+```
+
+   To fetch several pages in parallel, provide a file of URLs to
+   `scripts/multi_scrape`:
+
+   ```bash
+   scripts/multi_scrape URL.txt --out data/raw --limit 10 --workers 4
    ```
 
 2. **Extract frames**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,5 @@ scrape-data = "creating_mv.scrape_data:main"
 preprocess-data = "creating_mv.preprocess_data:main"
 train-model = "creating_mv.train_model:main"
 generate-output = "creating_mv.generate_output:main"
+multi-scrape = "creating_mv.multi_scrape:main"
 

--- a/scripts/multi_scrape
+++ b/scripts/multi_scrape
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from creating_mv.multi_scrape import main
+
+if __name__ == "__main__":
+    main()

--- a/src/creating_mv/multi_scrape.py
+++ b/src/creating_mv/multi_scrape.py
@@ -1,0 +1,35 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from .scrape_data import download_videos
+
+
+def _scrape_job(args):
+    idx, url, base_out, limit = args
+    out_dir = os.path.join(base_out, f"url_{idx}")
+    download_videos(url, out_dir, limit)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Download videos from multiple URLs concurrently")
+    parser.add_argument("urls_file", help="File containing one URL per line")
+    parser.add_argument("--out", default="data/raw", help="Base output directory")
+    parser.add_argument("--limit", type=int, default=10, help="Max videos per URL")
+    parser.add_argument("--workers", type=int, default=4, help="Number of parallel workers")
+    args = parser.parse_args()
+
+    with open(args.urls_file) as f:
+        urls = [line.strip() for line in f if line.strip()]
+
+    os.makedirs(args.out, exist_ok=True)
+
+    jobs = [(i, u, args.out, args.limit) for i, u in enumerate(urls, start=1)]
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for _ in ex.map(_scrape_job, jobs):
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support parallel scraping of multiple URLs
- expose new `multi-scrape` script in pyproject
- document usage in README

## Testing
- `python -m py_compile src/creating_mv/*.py scripts/*`
- `PYTHONPATH=src scripts/multi_scrape --help` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684873ae1a24832cb61cfff60631359a